### PR TITLE
Update install-on-linux.md - Debian versions

### DIFF
--- a/en/desktop/install-on-linux.md
+++ b/en/desktop/install-on-linux.md
@@ -40,10 +40,23 @@ To install the client, first add the signing key:
 ```sh
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8756C4F765C9AC3CB6B85D62379CE192D401AB61
 ```
-Then add the repo to your apt source list, here we use Debian 8 (jessie) as an example, so change it to "wheezy" if you're using Debian 7.
+
+Then add the repo to your apt source list, using the line corresponding to your debian version :
 
 ```
+# For Debian 7
+echo deb http://deb.seadrive.org wheezy main | sudo tee /etc/apt/sources.list.d/seafile.list
+
+# For Debian 8
 echo deb http://deb.seadrive.org jessie main | sudo tee /etc/apt/sources.list.d/seafile.list
+
+# For Debian 9
+echo deb http://deb.seadrive.org stretch main | sudo tee /etc/apt/sources.list.d/seafile.list
+```
+
+Update your local apt cache :
+
+```
 sudo apt-get update
 ```
 


### PR DESCRIPTION
Some users read through the documentation a little bit too fast, and end up with issues like this one : https://github.com/haiwen/seafile/issues/1735. This PR aims to make a clearer difference between Debian versions, and add a line for Debian 9 users (stretch) in the install documentation.

Side note : issue linked above seems to be outdated, since installation works fine with "stretch".