### PR TITLE
Updated instructions to allow install seadrive client on fedora 29/30

### DIFF
--- a/en/desktop/seadrive-fedora.repo
+++ b/en/desktop/seadrive-fedora.repo
@@ -1,6 +1,6 @@
 [seadrive]
 name=seadrive
-baseurl=https://rpm.seadrive.org/fedora
+baseurl=https://rpm.seadrive.org/fedora$releasever
 gpgcheck=0
 repo_gpgcheck=1
 gpgkey=https://bintray.com/user/downloadSubjectPublicKey?username=bintray


### PR DESCRIPTION
Now we support multiple versions of fedora