### PR TITLE
Custom files should go to `/etc` and not `/usr`

### DIFF
--- a/en/syncing_client/install_linux_client.md
+++ b/en/syncing_client/install_linux_client.md
@@ -7,7 +7,7 @@ You can find supported OS versions on <https://cloud.seatable.io/dtable/external
 To install the client, first add the signing key:
 
 ```
-sudo wget https://linux-clients.seafile.com/seafile.asc -O /usr/share/keyrings/seafile-keyring.asc
+sudo wget https://linux-clients.seafile.com/seafile.asc -O /etc/apt/trusted.gpg.d/seafile-keyring.asc
 
 ```
 


### PR DESCRIPTION
This is also the preferred location by `apt-key` as written in their [manual](https://manpages.debian.org/buster/apt/apt-key.8.en.html).