### PR TITLE
Move text out of command blocks

### DIFF
--- a/en/drive_client/drive_client_for_linux.md
+++ b/en/drive_client/drive_client_for_linux.md
@@ -15,38 +15,38 @@ If apt-get reports following error: "The following signatures couldn't be verifi
 
 Then add the repo to your apt source list, using the line corresponding to your Debian/Ubuntu version :
 
-```
 For Debian 9
+```
 sudo bash -c "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/seafile-keyring.asc] https://linux-clients.seafile.com/seadrive-deb/stretch/ stable main' > /etc/apt/sources.list.d/seadrive.list"
 
 ```
 
-```
 For Debian 10
+```
 sudo bash -c "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/seafile-keyring.asc] https://linux-clients.seafile.com/seadrive-deb/buster/ stable main' > /etc/apt/sources.list.d/seadrive.list"
 
 ```
 
-```
 For Debian 11
+```
 sudo bash -c "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/seafile-keyring.asc] https://linux-clients.seafile.com/seadrive-deb/bullseye/ stable main' > /etc/apt/sources.list.d/seadrive.list"
 
 ```
 
-```
 For Ubuntu 18.04
+```
 sudo bash -c "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/seafile-keyring.asc] https://linux-clients.seafile.com/seadrive-deb/bionic/ stable main' > /etc/apt/sources.list.d/seadrive.list"
 
 ```
 
-```
 For Ubuntu 20.04
+```
 sudo bash -c "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/seafile-keyring.asc] https://linux-clients.seafile.com/seadrive-deb/focal/ stable main' > /etc/apt/sources.list.d/seadrive.list"
 
 ```
 
-```
 For Ubuntu 22.04
+```
 sudo bash -c "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/seafile-keyring.asc] https://linux-clients.seafile.com/seadrive-deb/jammy/ stable main' > /etc/apt/sources.list.d/seadrive.list"
 
 ```

--- a/en/syncing_client/install_linux_client.md
+++ b/en/syncing_client/install_linux_client.md
@@ -15,38 +15,38 @@ If apt-get reports following error: "The following signatures couldn't be verifi
 
 Then add the repo to your apt source list, using the line corresponding to your Debian/Ubuntu version :
 
-```
 For Debian 9
+```
 sudo bash -c "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/seafile-keyring.asc] https://linux-clients.seafile.com/seafile-deb/stretch/ stable main' > /etc/apt/sources.list.d/seafile.list"
 
 ```
 
-```
 For Debian 10
+```
 sudo bash -c "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/seafile-keyring.asc] https://linux-clients.seafile.com/seafile-deb/buster/ stable main' > /etc/apt/sources.list.d/seafile.list"
 
 ```
 
-```
 For Debian 11
+```
 sudo bash -c "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/seafile-keyring.asc] https://linux-clients.seafile.com/seafile-deb/bullseye/ stable main' > /etc/apt/sources.list.d/seafile.list"
 
 ```
 
-```
 For Ubuntu 18.04
+```
 sudo bash -c "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/seafile-keyring.asc] https://linux-clients.seafile.com/seafile-deb/bionic/ stable main' > /etc/apt/sources.list.d/seafile.list"
 
 ```
 
-```
 For Ubuntu 20.04
+```
 sudo bash -c "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/seafile-keyring.asc] https://linux-clients.seafile.com/seafile-deb/focal/ stable main' > /etc/apt/sources.list.d/seafile.list"
 
 ```
 
-```
 For Ubuntu 22.04
+```
 sudo bash -c "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/seafile-keyring.asc] https://linux-clients.seafile.com/seafile-deb/jammy/ stable main' > /etc/apt/sources.list.d/seafile.list"
 
 ```


### PR DESCRIPTION
Markdown renderers usually provide a button to copy blocks of code. This simplifies copy-pasting commands into terminal. Unfortunately, some code blocks contain text and when copied as they are produce error like:
```
$ For Ubuntu 20.04

Command 'For' not found, did you mean:

  command 'tor' from deb tor (0.4.6.10-1)
  command 'vor' from deb vor (0.5.8-1)
  command 'oor' from deb openoverlayrouter (1.3.0+ds1-3)
  command 'sor' from deb pccts (1.33MR33-6.1)

Try: sudo apt install <deb name>

```
Moving text out of code blocks should improve user experience and streamline copy-pasting.