### PR TITLE
Optimize installation command for Ubuntu & Debian

### DIFF
--- a/en/syncing_client/install_linux_client.md
+++ b/en/syncing_client/install_linux_client.md
@@ -15,39 +15,9 @@ If apt-get reports following error: "The following signatures couldn't be verifi
 
 Then add the repo to your apt source list, using the line corresponding to your Debian/Ubuntu version :
 
-For Debian 9
+For Debian 9 / Debian 10 / Debian 11 / Ubuntu 18.04 / Ubuntu 20.04 / Ubuntu 22.04
 ```
-sudo bash -c "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/seafile-keyring.asc] https://linux-clients.seafile.com/seafile-deb/stretch/ stable main' > /etc/apt/sources.list.d/seafile.list"
-
-```
-
-For Debian 10
-```
-sudo bash -c "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/seafile-keyring.asc] https://linux-clients.seafile.com/seafile-deb/buster/ stable main' > /etc/apt/sources.list.d/seafile.list"
-
-```
-
-For Debian 11
-```
-sudo bash -c "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/seafile-keyring.asc] https://linux-clients.seafile.com/seafile-deb/bullseye/ stable main' > /etc/apt/sources.list.d/seafile.list"
-
-```
-
-For Ubuntu 18.04
-```
-sudo bash -c "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/seafile-keyring.asc] https://linux-clients.seafile.com/seafile-deb/bionic/ stable main' > /etc/apt/sources.list.d/seafile.list"
-
-```
-
-For Ubuntu 20.04
-```
-sudo bash -c "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/seafile-keyring.asc] https://linux-clients.seafile.com/seafile-deb/focal/ stable main' > /etc/apt/sources.list.d/seafile.list"
-
-```
-
-For Ubuntu 22.04
-```
-sudo bash -c "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/seafile-keyring.asc] https://linux-clients.seafile.com/seafile-deb/jammy/ stable main' > /etc/apt/sources.list.d/seafile.list"
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/seafile-keyring.asc] https://linux-clients.seafile.com/seafile-deb/$(lsb_release -cs)/ stable main" | sudo tee /etc/apt/sources.list.d/seafile.list > /dev/null
 
 ```
 


### PR DESCRIPTION
Optimize installation command for Ubuntu & Debian with `$(lsb_release -cs)` and `sudo tee`.

This is the same idea as what I suggested for the seadrive installation guide in Nov 2022: see commits 95ed6fc and 892ff7b 

I must have forgotten to edit this other guide back then